### PR TITLE
fixes #5 and #6

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -6,7 +6,7 @@ export ZOPEN_TYPE="TARBALL"
 
 ZOPEN_TARBALL_DIR=gawk-5.1.1
 export ZOPEN_TARBALL_URL="https://git.savannah.gnu.org/cgit/gawk.git/snapshot/${ZOPEN_TARBALL_DIR}.tar.gz"
-export ZOPEN_TARBALL_DEPS="curl gzip make"
+export ZOPEN_TARBALL_DEPS="curl gzip make diffutils"
 export ZOPEN_EXTRA_CPPFLAGS="-DATTRIBUTE_NORETURN=_Noreturn"
 
 export ZOPEN_BOOTSTRAP=skip

--- a/patches/PR1/ascii-io.patch
+++ b/patches/PR1/ascii-io.patch
@@ -7,19 +7,19 @@ index 91c94d9..3ac4b0d 100644
  }
  
 +#ifdef __MVS__
-+  #if (__CHARSET_LIB == 1)
-+  static int chgfdccsid(int fd, unsigned short ccsid) 
-+  {
-+    attrib_t attr;
-+    memset(&attr, 0, sizeof(attr));
-+    attr.att_filetagchg = 1;
-+    attr.att_filetag.ft_ccsid = ccsid;
-+    if (ccsid != FT_BINARY) {
-+      attr.att_filetag.ft_txtflag = 1;
-+    }
-+    return __fchattr(fd, &attr, sizeof(attr));
-+  }
-+  #endif
++ #if (__CHARSET_LIB == 1)
++ static int chgfdccsid(int fd, unsigned short ccsid) 
++ {
++ 	attrib_t attr;
++ 	memset(&attr, 0, sizeof(attr));
++ 	attr.att_filetagchg = 1;
++ 	attr.att_filetag.ft_ccsid = ccsid;
++ 	if (ccsid != FT_BINARY) {
++ 		attr.att_filetag.ft_txtflag = 1;
++ 	}
++ 	return __fchattr(fd, &attr, sizeof(attr));
++ }
++ #endif
 +#endif
 +
  /* redirect_string --- Redirection for printf and print commands, use string info */
@@ -31,9 +31,9 @@ index 91c94d9..3ac4b0d 100644
  						omode = binmode("a");
 +#endif
 +#ifdef __MVS__
-+  #if (__CHARSET_LIB == 1)
-+        chgfdccsid(fd, 819);
-+  #endif
++ #if (__CHARSET_LIB == 1)
++					 chgfdccsid(fd, 819);
++ #endif
  #endif
  					os_close_on_exec(fd, str, "file", "");
  					rp->output.fp = fdopen(fd, (const char *) omode);

--- a/patches/PR2/install-sh.patch
+++ b/patches/PR2/install-sh.patch
@@ -1,0 +1,13 @@
+diff --git a/build-aux/install-sh b/build-aux/install-sh
+index ec298b5..8357c99 100755
+--- a/build-aux/install-sh
++++ b/build-aux/install-sh
+@@ -236,7 +236,7 @@ if test -z "$dir_arg"; then
+   do_exit='(exit $ret); exit $ret'
+   trap "ret=129; $do_exit" 1
+   trap "ret=130; $do_exit" 2
+-  trap "ret=141; $do_exit" 13
++  trap "ret=141; $do_exit" SIGPIPE 
+   trap "ret=143; $do_exit" 15
+ 
+   # Set umask so as not to create temps with too-generous modes.


### PR DESCRIPTION
This enables diffutils so that all the tests that do 'diff -i' will now work.
This also fixes up the indenting of a previous patch so it is consistent with the rest of the code